### PR TITLE
Addition of sslmode to pgx and pg_dialect db types

### DIFF
--- a/config.go
+++ b/config.go
@@ -65,8 +65,8 @@ func RdbmsConfigFromEnv() *RdbmsConfig {
 		if sslMode, ok := sslModeMap[strings.ToLower(dbConfig.DbSSLMode)]; ok {
 			dbConfig.DbSSLMode = sslMode
 		} else {
-			dbConfig.DbSSLMode = defaultSSLMode
 			log.Printf("Error parsing DBSSLMODE value of \"%s\":  Will fall back to default DBSSLMODE value.\n", dbConfig.DbSSLMode)
+			dbConfig.DbSSLMode = defaultSSLMode
 		}
 	}
 

--- a/pg_dialect.go
+++ b/pg_dialect.go
@@ -1,6 +1,9 @@
 package goquery
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+)
 
 var pgDialect = DbDialect{
 	TableExistsStmt: `SELECT count(*) FROM information_schema.tables WHERE  table_schema = $1 AND table_name = $2`,

--- a/pg_dialect.go
+++ b/pg_dialect.go
@@ -11,7 +11,11 @@ var pgDialect = DbDialect{
 		return fmt.Sprintf("nextval('%s')", sequence)
 	},
 	Url: func(config *RdbmsConfig) string {
-		return fmt.Sprintf("user=%s password=%s host=%s port=%s database=%s sslmode=disable",
-			config.Dbuser, config.Dbpass, config.Dbhost, config.Dbport, config.Dbname)
+		if config.DbSSLMode == "" {
+			config.DbSSLMode = defaultSSLMode
+			log.Printf("No sslmode set, will fall back to default DBSSLMODE value %s. Set value in the dbconfig using DbSSLMode \n", defaultSSLMode)
+		}
+		return fmt.Sprintf("user=%s password=%s host=%s port=%s database=%s sslmode=%s",
+			config.Dbuser, config.Dbpass, config.Dbhost, config.Dbport, config.Dbname, config.DbSSLMode)
 	},
 }

--- a/pgx_db.go
+++ b/pgx_db.go
@@ -3,6 +3,7 @@ package goquery
 import (
 	"context"
 	"fmt"
+	"log"
 	"reflect"
 	"time"
 

--- a/pgx_db.go
+++ b/pgx_db.go
@@ -107,8 +107,12 @@ type PgxDb struct {
 }
 
 func NewPgxConnection(config *RdbmsConfig) (PgxDb, error) {
-	dburl := fmt.Sprintf("user=%s password=%s host=%s port=%s database=%s sslmode=disable",
-		config.Dbuser, config.Dbpass, config.Dbhost, config.Dbport, config.Dbname)
+	if config.DbSSLMode == "" {
+		config.DbSSLMode = defaultSSLMode
+		log.Printf("No sslmode set, will fall back to default DBSSLMODE value %s. Set value in the dbconfig using DbSSLMode \n", defaultSSLMode)
+	}
+	dburl := fmt.Sprintf("user=%s password=%s host=%s port=%s database=%s sslmode=%s",
+		config.Dbuser, config.Dbpass, config.Dbhost, config.Dbport, config.Dbname, config.DbSSLMode)
 
 	if config.PoolMaxConns > 0 {
 		dburl = fmt.Sprintf("%s %s=%d", dburl, "pool_max_conns", config.PoolMaxConns)


### PR DESCRIPTION
To keep developer changes to a minimum, this should not require any changes to continue using.

If no changes are made goquery will set sslmode=disable as the default

If a dev wants to explicitly set the sslmode, set it either via the RdbmsConfig type declaration:
`	dbconfig := gq.RdbmsConfig{
		Dbuser:   Dbuser,
		Dbpass:   Dbpass,
		Dbport:   Dbport,
		Dbhost:   Dbhost,
		Dbname:   Dbname,
		DbSSLMode: "prefer",
		DbDriver: "pgx",
		DbStore:  "pgx",
	}
`
Or via the RdbmsConfigFromEnv() by using the DBSSLMODE env variable.

Currently accepted sslmodes:
- disable
- allow
- prefer
- require
- verify-ca
- verify-full

If a sslmode is sent not in the above list, it will log a warning and set the sslmode to disable.